### PR TITLE
BTBRD-10: Replace default browser serif font

### DIFF
--- a/src/styles/base/_colours.scss
+++ b/src/styles/base/_colours.scss
@@ -1,0 +1,8 @@
+$colours: (
+  white: #fff,
+  black: #000
+);
+
+@function get-colour($name) {
+  @return map_get($colours, $name);
+}

--- a/src/styles/base/_reset.scss
+++ b/src/styles/base/_reset.scss
@@ -1,47 +1,62 @@
-/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+@use "typography";
+@use "colours";
+
+/*!
+ * bitbird-ng - Reset | MIT License | https://github.com/rossyman/bitbird-ng
+ *
+ * Modifications of:
+ *   -  reboot.css - MIT Licence - https://github.com/twbs/bootstrap/blob/main/scss/_reboot.scss
+ *   -  normalize.css - MIT License - https://github.com/necolas/normalize.css
+ */
 
 /* Document
    ========================================================================== */
 
 /**
- * 1. Apply anti-aliasing on text to all elements.
- * 2. Ensure all elements have border-box, box-sizing.
- * 3. Apply font kerning
+ * Ensure all elements have border-box, box-sizing.
  */
 
 *::before,
 *::after,
 * {
-  -webkit-font-smoothing: antialiased; /* 1 */
-  -moz-osx-font-smoothing: grayscale; /* 1 */
-  box-sizing: border-box; /* 2 */
-  text-rendering: optimizeLegibility; /* 3 */
-  font-feature-settings: "kern"; /* 3 */
-  -webkit-font-feature-settings: "kern"; /* 3 */
-  -moz-font-feature-settings: "kern"; /* 3 */
-  -moz-font-feature-settings: "kern=1"; /* 3 */
+  box-sizing: border-box;
 }
 
 /**
  * 1. Correct the line height in all browsers.
  * 2. Prevent adjustments of font size after orientation changes in iOS.
+ * 3. Change the default tap highlight to be completely transparent in iOS.
+ * 4. Apply anti-aliasing on text to all elements.
+ * 5. Apply font kerning.
  */
 
 html {
-  line-height: 1.15; /* 1 */
+  line-height: typography.$font-line-height; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
+  -webkit-tap-highlight-color: rgba(colours.get-colour(black), 0); /* 3 */
+  -webkit-font-smoothing: antialiased; /* 4 */
+  -moz-osx-font-smoothing: grayscale; /* 4 */
+  text-rendering: optimizeLegibility; /* 5 */
+  font-feature-settings: "kern"; /* 5 */
+  -webkit-font-feature-settings: "kern"; /* 5 */
+  -moz-font-feature-settings: "kern"; /* 5 */
+  -moz-font-feature-settings: "kern=1"; /* 5 */
 }
 
 /* Sections
    ========================================================================== */
 
 /**
- * Remove the margin in all browsers.
+ * 1. Remove the margin in all browsers.
+ * 2. As a best practice, apply a default `background-color`.
+ * 3. Set the default system font stack
  */
 
 body {
-  margin: 0;
-  font-size: 1rem;
+  margin: 0; /* 1 */
+  font-size: typography.$font-size;
+  background-color: colours.get-colour(white); /* 2 */
+  font-family: typography.$font-family; /* 3 */
 }
 
 /**
@@ -58,7 +73,7 @@ main {
  */
 
 h1 {
-  font-size: 2em;
+  font-size: typography.$font-size * 2;
   margin: 0.67em 0;
 }
 
@@ -83,7 +98,7 @@ hr {
 
 pre {
   font-family: monospace, monospace; /* 1 */
-  font-size: 1em; /* 2 */
+  font-size: typography.$font-size; /* 2 */
 }
 
 /* Text-level semantics
@@ -126,7 +141,7 @@ code,
 kbd,
 samp {
   font-family: monospace, monospace; /* 1 */
-  font-size: 1em; /* 2 */
+  font-size: typography.$font-size; /* 2 */
 }
 
 /**
@@ -184,7 +199,7 @@ select,
 textarea {
   font-family: inherit; /* 1 */
   font-size: 100%; /* 1 */
-  line-height: 1.15; /* 1 */
+  line-height: typography.$font-line-height; /* 1 */
   margin: 0; /* 2 */
 }
 
@@ -267,7 +282,7 @@ legend {
   padding: 0; /* 3 */
   white-space: normal; /* 1 */
   width: 100%; /* 1 */
-  font-size: 1.5rem; /* 4 */
+  font-size: typography.$font-size * 1.5; /* 4 */
   line-height: inherit; /* 4 */
 }
 

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -1,0 +1,10 @@
+$font-family: -apple-system,
+              BlinkMacSystemFont,
+              "Segoe UI",
+              Helvetica,
+              Arial,
+              sans-serif,
+              "Apple Color Emoji",
+              "Segoe UI Emoji";
+$font-size: 1rem;
+$font-line-height: 1.15;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,4 +1,4 @@
 /*! bitbird-ng | MIT License | https://github.com/rossyman/bitbird-ng */
 
-/* Vendor Imports */
-@use "vendor/normalize";
+/* Base Styles */
+@use "base/reset";


### PR DESCRIPTION
Replace the default browser serif font with a nicer sans-serif system stack 🕊

```
font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
```

### Acceptance Criteria

- [x] Replace the browser default font with the system font stack

### Linked project issue
Closes #28 